### PR TITLE
CentOS 5/6 both use the same default.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,6 +1,6 @@
 class limits::params {
     case $operatingsystem {
-        /(Ubuntu|Debian)/: {
+        /(Ubuntu|Debian|CentOS)/: {
             $limits_dir = '/etc/security/limits.d/'
         }
     }


### PR DESCRIPTION
Tested on 5/6. Didn't test on RHEL so I didn't add it.
