### PR TITLE
Make purging the limits.d directory optional.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,10 +1,10 @@
-class limits::config {
+class limits::config ($manage_limitsd) {
     file { $limits::params::limits_dir:
         ensure  => directory,
         owner   => root,
         group   => root,
         force   => true,
-        purge   => true,
+        purge   => $manage_limitsd,
         recurse => true,
     }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,6 +4,10 @@
 #
 # Parameters:
 #
+# [*manage_limitsd*]
+#   Should the limits module purge any non puppet managed files from
+#   ${limits::params::limits_dir}
+#
 # Actions:
 #
 # Requires:
@@ -11,6 +15,11 @@
 # Sample Usage:
 #
 # [Remember: No empty lines between comments and class definition]
-class limits {
-	include limits::params, limits::config
+class limits ($manage_limitsd = true) {
+
+  include limits::params
+
+  class {'limits::config':
+    manage_limitsd => $manage_limitsd
+  }
 }

--- a/manifests/limits.pp
+++ b/manifests/limits.pp
@@ -1,5 +1,6 @@
 define limits::limits ($ensure = present, $user = undef, $limit_type = undef, $hard = undef, $soft = undef) {
-    include limits
+
+    require limits
 
     file { "${limits::params::limits_dir}${name}":
         ensure  => $ensure,

--- a/tests/no_purge.pp
+++ b/tests/no_purge.pp
@@ -1,0 +1,20 @@
+# setup security limits (soft/hard nofiles)
+class {'limits':
+  manage_limitsd => false,
+}
+
+limits::limits { 'puppet_noproc':
+  ensure     => present,
+  user       => 'puppet',
+  limit_type => 'nproc',
+  soft       => 'true',
+  hard       => 'true',
+}
+
+limits::limits { 'star_nofile':
+  ensure     => present,
+  user       => '*',
+  limit_type => 'nofile',
+  soft       => 'true',
+  hard       => 'true',
+}


### PR DESCRIPTION
Many packages install files into the limits.d directory. Allow the user to
decide if they want to purge non puppet managed files.

The default stays purging to keep backwards compatibility.
