### PR TITLE
Added RedHat to the list of acceptable OS families

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,6 +1,6 @@
 class limits::params {
   case $::osfamily {
-    'Debian': {
+    'Debian','RedHat': {
       $limits_dir = '/etc/security/limits.d/'
     }
     default: {


### PR DESCRIPTION
RHEL6 uses the same directory for limit files.  Added RedHat to the list of acceptable OS families.
