### PR TITLE
fix regex. so it does not match files like blaconf

### DIFF
--- a/manifests/limits.pp
+++ b/manifests/limits.pp
@@ -8,7 +8,7 @@ define limits::limits(
 ) {
   include limits::params
 
-  if $name =~ /.conf$/ {
+  if $name =~ /\.conf$/ {
     $target_file = "${limits::params::limits_dir}${name}"
   } else {
     $target_file = "${limits::params::limits_dir}${name}.conf"


### PR DESCRIPTION
It s just a minor issue, but in case you have a name like foobarconf the old regex would match and create a wrong file.
