### PR TITLE
remove double case

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,11 +4,7 @@ class limits::params {
       $limits_dir = '/etc/security/limits.d/'
     }
     default: {
-      case $::operatingsystem {
-        default: {
-          fail("Unsupported platform: ${::osfamily}/${::operatingsystem}")
-        }
-      }
+      fail("Unsupported platform: ${::osfamily}/${::operatingsystem}")
     }
   }
 }


### PR DESCRIPTION
There is no reason for the second case directive, or at least I do not see it :)
