### PR TITLE
Update metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -35,9 +35,6 @@
     }
   ],
   "description": "Manage user limits via puppet",
-  "types": [
-  
-  ],
   "dependencies": [
   
   ]


### PR DESCRIPTION
Removed the Types reference in the metadata.json as this field has been deprecated and is causing metadata-json-lint to fail.