### PR TITLE
Add manage_limits_d_dir bool class param

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ group :development, :test do
   gem 'rspec-puppet'
   gem 'metadata-json-lint'
   gem 'puppetlabs_spec_helper'
-  gem 'puppet-lint', :git => 'https://github.com/rodjek/puppet-lint.git'
+  gem 'puppet-lint', '>= 1.0', '< 3.0'
   gem 'puppet-lint-absolute_classname-check'
   gem 'puppet-lint-alias-check'
   gem 'puppet-lint-empty_string-check'
@@ -29,4 +29,12 @@ end
 # rspec must be v2 for ruby 1.8.7
 if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
   gem 'rspec', '~> 2.0'
+end
+
+if RUBY_VERSION < '2.0'
+  # json 2.x requires ruby 2.0. Lock to 1.8
+  gem 'json', '~> 1.8'
+  gem 'json_pure', '~> 1.0'
+else
+  gem 'json'
 end

--- a/README.md
+++ b/README.md
@@ -57,3 +57,16 @@ or just do not call the class.
     }
 ```
 One of hard, soft or both must be set!
+
+### Do not manage /etc/security/limits.d/
+
+In an effort to make this module compatible with similar modules, e.g.
+[puppet-module-pam](https://github.com/ghoneycutt/puppet-module-pam), management
+of `/etc/security/limits.d` can be disabled by way of the `manage_limits_d_dir`
+class parameter:
+
+```puppet
+class { 'limits':
+  manage_limits_d_dir => false,
+}
+```

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,16 +2,19 @@
 #
 class limits (
   $purge_limits_d_dir = true,
-  $entries_hash = hiera_hash(limits::entries, {})
+  $entries_hash = hiera_hash(limits::entries, {}),
+  $manage_limits_d_dir = true
 ) inherits ::limits::params {
 
-  file { $limits::params::limits_dir:
-    ensure  => 'directory',
-    owner   => 'root',
-    group   => 'root',
-    force   => true,
-    purge   => $purge_limits_d_dir,
-    recurse => true,
+  if $manage_limits_d_dir == true {
+    file { $limits::params::limits_dir:
+      ensure  => 'directory',
+      owner   => 'root',
+      group   => 'root',
+      force   => true,
+      purge   => $purge_limits_d_dir,
+      recurse => true,
+    }
   }
 
   ### Create instances for integration with Hiera

--- a/spec/classes/limits_spec.rb
+++ b/spec/classes/limits_spec.rb
@@ -3,6 +3,7 @@ describe 'limits' do
 
   let :default_params do
     {
+      :manage_limits_d_dir => true,
       :purge_limits_d_dir => true
     }
   end
@@ -10,9 +11,12 @@ describe 'limits' do
   [ {},
     {
       :purge_limits_d_dir => false
+    },
+    {
+      :manage_limits_d_dir => false
     }
   ].each do |param_set|
-    describe "when #{param_set == {} ? "using default" : "specifying"} class parameters" do
+    describe "when #{param_set == {} ? "using default" : "specifying #{param_set}"} class parameters" do
 
       let :param_hash do
         default_params.merge(param_set)
@@ -34,14 +38,19 @@ describe 'limits' do
 
           it { should contain_class('limits::params') }
 
-          it { should contain_file('/etc/security/limits.d/').with(
-            'ensure'  => 'directory',
-            'owner'   => 'root',
-            'group'   => 'root',
-            'force'   => true,
-            'recurse' => true,
-            'purge'   => param_hash[:purge_limits_d_dir]
-          )}
+          it do
+            if params[:manage_limits_d_dir] == false
+              should_not contain_file('/etc/security/limits.d/')
+            else
+              should contain_file('/etc/security/limits.d/').with(
+              'ensure'  => 'directory',
+              'owner'   => 'root',
+              'group'   => 'root',
+              'force'   => true,
+              'recurse' => true,
+              'purge'   => param_hash[:purge_limits_d_dir])
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
Without this patch the use of the limits module in conjunction with the
[pam](https://git.io/v6qAH) module causes the following error:

```
Failed to apply catalog: Cannot alias File[limits_d] to ["/etc/security/limits.d"] at
/etc/puppet/ghoneycutt-modules/pam/manifests/limits.pp:62;
resource ["File", "/etc/security/limits.d"] already declared at
/etc/puppet/environments/development/modules/limits/manifests/init.pp:15
```

This patch addresses the issue by allowing the end user to disable management
of the limits.d directory.  This is desirable because the end user may still
wish to manage limits using the `limits::entries` Hiera data value in
conjunction with the pam module.
