### PR TITLE
Allow for overriding the limits_dir through parameter passing

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,13 +1,14 @@
 # == Class: limits
 #
 class limits (
+  $limits_dir           = $::limits::params::limits_dir,
   $purge_limits_d_dir   = true,
   $entries_hash         = hiera_hash(limits::entries, {}),
   $manage_limits_d_dir  = true,
 ) inherits ::limits::params {
 
   if $manage_limits_d_dir == true {
-    file { $limits::params::limits_dir:
+    file { $limits_dir:
       ensure  => 'directory',
       owner   => 'root',
       group   => 'root',


### PR DESCRIPTION
Currently, the main class `::limits` uses the `$limits_dir` variable from the `::limits::params` namespace directly inside its body. It is not a class parameter, thus forcing users to edit the `::limits::params` class to change the path.

While I agree it is not so common to change this path, a good module should not restrict the user to do so. This change introduces the new `::limits::limits_dir` parameter so it can be easily overriden either from a class declaration or through automatic data bindings.