### PR TITLE
Allow managing multiple settings in one file

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,3 +1,10 @@
 fixtures:
+  repositories:
+    stdlib:
+      repo: https://github.com/puppetlabs/puppetlabs-stdlib.git
+      ref: 4.13.1
+    concat:
+      repo: https://github.com/puppetlabs/puppetlabs-concat.git
+      ref: v7.3.0
   symlinks:
     limits: "#{source_dir}"

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ It creates files in `/etc/security/limits.d` and does not manage the file `/etc/
   * `hard`: (Integer) the hard value
   * `soft`: (Integer) the soft value
   * `both`: (Integer) the value of both soft and hard
+  * `target`: (String) Optional name of file in `limits_dir` to set limit settings to. Will ignore other file naming logic when provided.
 
 
 ### Using hiera

--- a/metadata.json
+++ b/metadata.json
@@ -58,10 +58,6 @@
   ],
   "dependencies": [
     {
-      "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 9.0.0"
-    },
-    {
       "name": "puppetlabs/concat",
       "version_requirement": ">= 7.3.0 < 8.0.0"
     }

--- a/metadata.json
+++ b/metadata.json
@@ -57,5 +57,13 @@
     }
   ],
   "dependencies": [
+    {
+      "name": "puppetlabs/stdlib",
+      "version_requirement": ">= 4.13.1 < 9.0.0"
+    },
+    {
+      "name": "puppetlabs/concat",
+      "version_requirement": ">= 7.3.0 < 8.0.0"
+    }
   ]
 }

--- a/spec/acceptance/limits_spec.rb
+++ b/spec/acceptance/limits_spec.rb
@@ -35,7 +35,58 @@ describe 'limits::limits define' do
 
     describe file('/etc/security/limits.d/user_nofile.conf') do
       it { is_expected.to be_file }
-      it { is_expected.to contain 'user          -     nofile          12345' }
+      it { is_expected.to contain "# Managed by Puppet\n\n#<domain>    <type> <item>          <value>\nuser          -     nofile          12345" }
+    end
+  end
+
+  context 'with target specified managed file' do
+    it 'create a puppet managed file' do
+      pp = <<-PP
+      limits::limits { 'item':
+        user       => 'user',
+        limit_type => 'nofile',
+        both       => 12345,
+        target     => '00-item.conf'
+      }
+      PP
+
+      # Run it twice and test for idempotency
+      apply_manifest(pp, catch_failures: true)
+      expect(apply_manifest(pp, catch_failures: true).exit_code).to be_zero
+    end
+
+    describe file('/etc/security/limits.d/00-item.conf') do
+      it { is_expected.to be_file }
+      it { is_expected.to contain "# Managed by Puppet\n\n#<domain>    <type> <item>          <value>\nuser          -     nofile          12345" }
+    end
+  end
+
+  context 'with multiple target specified managed limit' do
+    it 'create a puppet managed file' do
+      pp = <<-PP
+      limits::limits { 'item':
+        user       => 'user',
+        limit_type => 'nofile',
+        both       => 12345,
+        target     => '00-item.conf'
+      }
+
+      limits::limits { 'item2':
+        user       => 'other_user',
+        limit_type => 'nproc',
+        both       => 54321,
+        target     => '00-item.conf'
+      }
+      PP
+
+      # Run it twice and test for idempotency
+      apply_manifest(pp, catch_failures: true)
+      expect(apply_manifest(pp, catch_failures: true).exit_code).to be_zero
+    end
+
+    describe file('/etc/security/limits.d/00-item.conf') do
+      it { is_expected.to be_file }
+      it { is_expected.to contain "# Managed by Puppet\n\n#<domain>    <type> <item>          <value>\nuser          -     nofile          12345\nother_user    -     nproc           54321\n" }
     end
   end
 end

--- a/spec/defines/limits_spec.rb
+++ b/spec/defines/limits_spec.rb
@@ -38,11 +38,65 @@ describe 'limits::limits', type: :define do
           }
 
           it {
-            is_expected.to contain_file(filename).with(
-              'ensure'  => 'present',
-              'content' => "# Managed by Puppet\n\n#<domain>    <type> <item>          <value>\nusername      hard  nofile          16384\nusername      soft  nofile          16384\n",
-              'owner'   => 'root',
-              'group'   => 'root'
+            is_expected.to contain_file('/etc/security/limits.d').with(
+              path: '/etc/security/limits.d',
+              ensure: 'directory',
+              owner: 'root',
+              group: 'root',
+              force: true,
+              purge: true,
+              recurse: true
+            )
+          }
+
+          it {
+            is_expected.to contain_concat(filename).with(
+              name: filename,
+              path: filename
+            )
+          }
+
+          it {
+            is_expected.to contain_concat__fragment('top_/etc/security/limits.d/username_nofile.conf').with(
+              name: 'top_/etc/security/limits.d/username_nofile.conf',
+              target: filename,
+              content: "# Managed by Puppet\n\n#<domain>    <type> <item>          <value>",
+              order: '01'
+            )
+          }
+
+          it {
+            is_expected.to contain_concat__fragment('username_nofile').with(
+              name: 'username_nofile',
+              target: filename,
+              content: "username      hard  nofile          16384\nusername      soft  nofile          16384\n",
+              order: '10'
+            )
+          }
+
+          it {
+            is_expected.to contain_concat_fragment('top_/etc/security/limits.d/username_nofile.conf').with(
+              name: 'top_/etc/security/limits.d/username_nofile.conf',
+              target: filename,
+              order: '01',
+              content: "# Managed by Puppet\n\n#<domain>    <type> <item>          <value>"
+            )
+          }
+
+          it {
+            is_expected.to contain_concat_fragment('username_nofile').with(
+              name: 'username_nofile',
+              target: filename,
+              order: '10',
+              content: "username      hard  nofile          16384\nusername      soft  nofile          16384\n"
+            )
+          }
+
+          it {
+            is_expected.to contain_concat_file(filename).with(
+              path: filename,
+              owner: 'root',
+              group: 'root'
             )
           }
         end
@@ -61,11 +115,65 @@ describe 'limits::limits', type: :define do
           }
 
           it {
-            is_expected.to contain_file(filename).with(
-              'ensure'  => 'present',
-              'content' => "# Managed by Puppet\n\n#<domain>    <type> <item>          <value>\nusername      hard  nofile          16384\nusername      soft  nofile          16384\n",
-              'owner'   => 'root',
-              'group'   => 'root'
+            is_expected.to contain_file('/etc/security/limits.d').with(
+              path: '/etc/security/limits.d',
+              ensure: 'directory',
+              owner: 'root',
+              group: 'root',
+              force: true,
+              purge: true,
+              recurse: true
+            )
+          }
+
+          it {
+            is_expected.to contain_concat(filename).with(
+              name: filename,
+              path: filename
+            )
+          }
+
+          it {
+            is_expected.to contain_concat__fragment('top_/etc/security/limits.d/username_nofile.conf').with(
+              name: 'top_/etc/security/limits.d/username_nofile.conf',
+              target: filename,
+              content: "# Managed by Puppet\n\n#<domain>    <type> <item>          <value>",
+              order: '01'
+            )
+          }
+
+          it {
+            is_expected.to contain_concat__fragment('username_nofile').with(
+              name: 'username_nofile',
+              target: filename,
+              content: "username      hard  nofile          16384\nusername      soft  nofile          16384\n",
+              order: '10'
+            )
+          }
+
+          it {
+            is_expected.to contain_concat_fragment('top_/etc/security/limits.d/username_nofile.conf').with(
+              name: 'top_/etc/security/limits.d/username_nofile.conf',
+              target: filename,
+              order: '01',
+              content: "# Managed by Puppet\n\n#<domain>    <type> <item>          <value>"
+            )
+          }
+
+          it {
+            is_expected.to contain_concat_fragment('username_nofile').with(
+              name: 'username_nofile',
+              target: filename,
+              order: '10',
+              content: "username      hard  nofile          16384\nusername      soft  nofile          16384\n"
+            )
+          }
+
+          it {
+            is_expected.to contain_concat_file(filename).with(
+              path: filename,
+              owner: 'root',
+              group: 'root'
             )
           }
         end
@@ -82,10 +190,9 @@ describe 'limits::limits', type: :define do
           end
 
           it {
-            is_expected.to contain_file(filename).with(
-              'ensure' => 'absent',
-              'owner' => 'root',
-              'group' => 'root'
+            is_expected.to contain_concat_file(filename).with(
+              path: filename,
+              ensure: 'absent'
             )
           }
         end
@@ -100,10 +207,9 @@ describe 'limits::limits', type: :define do
           end
 
           it {
-            is_expected.to contain_file(filename).with(
-              'ensure' => 'absent',
-              'owner' => 'root',
-              'group' => 'root'
+            is_expected.to contain_concat_file(filename).with(
+              path: filename,
+              ensure: 'absent'
             )
           }
         end
@@ -129,11 +235,151 @@ describe 'limits::limits', type: :define do
           }
 
           it {
-            is_expected.to contain_file(filename).with(
-              'ensure' => 'present',
-              'content' => "# Managed by Puppet\n\n#<domain>    <type> <item>          <value>\nusername      -     nofile          16384\n",
-              'owner' => 'root',
-              'group' => 'root'
+            is_expected.to contain_file('/etc/security/limits.d').with(
+              path: '/etc/security/limits.d',
+              ensure: 'directory',
+              owner: 'root',
+              group: 'root',
+              force: true,
+              purge: true,
+              recurse: true
+            )
+          }
+
+          it {
+            is_expected.to contain_concat(filename).with(
+              name: filename,
+              path: filename
+            )
+          }
+
+          it {
+            is_expected.to contain_concat__fragment('top_/etc/security/limits.d/username_nofile.conf').with(
+              name: 'top_/etc/security/limits.d/username_nofile.conf',
+              target: filename,
+              content: "# Managed by Puppet\n\n#<domain>    <type> <item>          <value>",
+              order: '01'
+            )
+          }
+
+          it {
+            is_expected.to contain_concat__fragment('username_nofile').with(
+              name: 'username_nofile',
+              target: filename,
+              content: "username      -     nofile          16384\n",
+              order: '10'
+            )
+          }
+
+          it {
+            is_expected.to contain_concat_fragment('top_/etc/security/limits.d/username_nofile.conf').with(
+              name: 'top_/etc/security/limits.d/username_nofile.conf',
+              target: filename,
+              order: '01',
+              content: "# Managed by Puppet\n\n#<domain>    <type> <item>          <value>"
+            )
+          }
+
+          it {
+            is_expected.to contain_concat_fragment('username_nofile').with(
+              name: 'username_nofile',
+              target: filename,
+              order: '10',
+              content: "username      -     nofile          16384\n"
+            )
+          }
+
+          it {
+            is_expected.to contain_concat_file(filename).with(
+              path: filename,
+              owner: 'root',
+              group: 'root'
+            )
+          }
+        end
+
+        context 'when creating a limits entry with target file name specified' do
+          let(:title) { 'username_nofile.conf' }
+          let :params do
+            {
+              user: 'username',
+              limit_type: 'nofile',
+              ensure: 'present',
+              both: 16_384,
+              target: '99-service.conf'
+            }
+          end
+
+          it {
+            is_expected.to contain_limits__limits('username_nofile.conf').with(
+              user: 'username',
+              limit_type: 'nofile',
+              ensure: 'present',
+              both: 16_384,
+              target: '99-service.conf'
+            )
+          }
+
+          it {
+            is_expected.to contain_file('/etc/security/limits.d').with(
+              path: '/etc/security/limits.d',
+              ensure: 'directory',
+              owner: 'root',
+              group: 'root',
+              force: true,
+              purge: true,
+              recurse: true
+            )
+          }
+
+          it {
+            is_expected.to contain_concat('/etc/security/limits.d/99-service.conf').with(
+              name: '/etc/security/limits.d/99-service.conf',
+              path: '/etc/security/limits.d/99-service.conf'
+            )
+          }
+
+          it {
+            is_expected.to contain_concat__fragment('top_/etc/security/limits.d/99-service.conf').with(
+              name: 'top_/etc/security/limits.d/99-service.conf',
+              target: '/etc/security/limits.d/99-service.conf',
+              content: "# Managed by Puppet\n\n#<domain>    <type> <item>          <value>",
+              order: '01'
+            )
+          }
+
+          it {
+            is_expected.to contain_concat__fragment('username_nofile').with(
+              name: 'username_nofile',
+              target: '/etc/security/limits.d/99-service.conf',
+              content: "username      -     nofile          16384\n",
+              order: '10'
+            )
+          }
+
+          it {
+            is_expected.to contain_concat_fragment('top_/etc/security/limits.d/99-service.conf').with(
+              name: 'top_/etc/security/limits.d/99-service.conf',
+              target: '/etc/security/limits.d/99-service.conf',
+              order: '01',
+              content: "# Managed by Puppet\n\n#<domain>    <type> <item>          <value>"
+            )
+          }
+
+          it {
+            is_expected.to contain_concat_fragment('username_nofile').with(
+              name: 'username_nofile',
+              target: '/etc/security/limits.d/99-service.conf',
+              order: '10',
+              content: "username      -     nofile          16384\n"
+            )
+          }
+
+          it {
+            is_expected.to contain_concat_file('/etc/security/limits.d/99-service.conf').with(
+              path: '/etc/security/limits.d/99-service.conf',
+              owner: 'root',
+              group: 'root'
             )
           }
         end
@@ -151,11 +397,65 @@ describe 'limits::limits', type: :define do
           it { is_expected.to compile.with_all_deps }
 
           it {
-            is_expected.to contain_file('/etc/security/limits.d/default_nofile.conf').with(
-              'ensure'  => 'present',
-              'content' => "# Managed by Puppet\n\n#<domain>    <type> <item>          <value>\n*             -     nofile          16384\n",
-              'owner'   => 'root',
-              'group'   => 'root'
+            is_expected.to contain_file('/etc/security/limits.d').with(
+              path: '/etc/security/limits.d',
+              ensure: 'directory',
+              owner: 'root',
+              group: 'root',
+              force: true,
+              purge: true,
+              recurse: true
+            )
+          }
+
+          it {
+            is_expected.to contain_concat('/etc/security/limits.d/default_nofile.conf').with(
+              name: '/etc/security/limits.d/default_nofile.conf',
+              path: '/etc/security/limits.d/default_nofile.conf'
+            )
+          }
+
+          it {
+            is_expected.to contain_concat__fragment('top_/etc/security/limits.d/default_nofile.conf').with(
+              name: 'top_/etc/security/limits.d/default_nofile.conf',
+              target: '/etc/security/limits.d/default_nofile.conf',
+              content: "# Managed by Puppet\n\n#<domain>    <type> <item>          <value>",
+              order: '01'
+            )
+          }
+
+          it {
+            is_expected.to contain_concat__fragment('*_nofile').with(
+              name: '*_nofile',
+              target: '/etc/security/limits.d/default_nofile.conf',
+              content: "*             -     nofile          16384\n",
+              order: '10'
+            )
+          }
+
+          it {
+            is_expected.to contain_concat_fragment('top_/etc/security/limits.d/default_nofile.conf').with(
+              name: 'top_/etc/security/limits.d/default_nofile.conf',
+              target: '/etc/security/limits.d/default_nofile.conf',
+              order: '01',
+              content: "# Managed by Puppet\n\n#<domain>    <type> <item>          <value>"
+            )
+          }
+
+          it {
+            is_expected.to contain_concat_fragment('*_nofile').with(
+              name: '*_nofile',
+              target: '/etc/security/limits.d/default_nofile.conf',
+              order: '10',
+              content: "*             -     nofile          16384\n"
+            )
+          }
+
+          it {
+            is_expected.to contain_concat_file('/etc/security/limits.d/default_nofile.conf').with(
+              path: '/etc/security/limits.d/default_nofile.conf',
+              owner: 'root',
+              group: 'root'
             )
           }
         end
@@ -169,11 +469,65 @@ describe 'limits::limits', type: :define do
           end
 
           it {
-            is_expected.to contain_file('/etc/security/limits.d/root_nofile.conf').with(
-              'ensure'  => 'present',
-              'content' => "# Managed by Puppet\n\n#<domain>    <type> <item>          <value>\nroot          hard  nofile          12345\n",
-              'owner'   => 'root',
-              'group'   => 'root'
+            is_expected.to contain_file('/etc/security/limits.d').with(
+              path: '/etc/security/limits.d',
+              ensure: 'directory',
+              owner: 'root',
+              group: 'root',
+              force: true,
+              purge: true,
+              recurse: true
+            )
+          }
+
+          it {
+            is_expected.to contain_concat('/etc/security/limits.d/root_nofile.conf').with(
+              name: '/etc/security/limits.d/root_nofile.conf',
+              path: '/etc/security/limits.d/root_nofile.conf'
+            )
+          }
+
+          it {
+            is_expected.to contain_concat__fragment('top_/etc/security/limits.d/root_nofile.conf').with(
+              name: 'top_/etc/security/limits.d/root_nofile.conf',
+              target: '/etc/security/limits.d/root_nofile.conf',
+              content: "# Managed by Puppet\n\n#<domain>    <type> <item>          <value>",
+              order: '01'
+            )
+          }
+
+          it {
+            is_expected.to contain_concat__fragment('root_nofile').with(
+              name: 'root_nofile',
+              target: '/etc/security/limits.d/root_nofile.conf',
+              content: "root          hard  nofile          12345\n",
+              order: '10'
+            )
+          }
+
+          it {
+            is_expected.to contain_concat_fragment('top_/etc/security/limits.d/root_nofile.conf').with(
+              name: 'top_/etc/security/limits.d/root_nofile.conf',
+              target: '/etc/security/limits.d/root_nofile.conf',
+              order: '01',
+              content: "# Managed by Puppet\n\n#<domain>    <type> <item>          <value>"
+            )
+          }
+
+          it {
+            is_expected.to contain_concat_fragment('root_nofile').with(
+              name: 'root_nofile',
+              target: '/etc/security/limits.d/root_nofile.conf',
+              order: '10',
+              content: "root          hard  nofile          12345\n"
+            )
+          }
+
+          it {
+            is_expected.to contain_concat_file('/etc/security/limits.d/root_nofile.conf').with(
+              path: '/etc/security/limits.d/root_nofile.conf',
+              owner: 'root',
+              group: 'root'
             )
           }
         end

--- a/templates/limits.erb
+++ b/templates/limits.erb
@@ -1,6 +1,3 @@
-# Managed by Puppet
-
-#<domain>    <type> <item>          <value>
 <% if @both then -%>
 <%= "%-12s" % @real_user %>  -     <%= "%-14s" % @real_type %>  <%= @both %>
 <% else -%>


### PR DESCRIPTION
Contents:
* add optional `target` parameter to select file inside limits_dir to save settings. Allows multiple settings inside one file - addresses #42
* switches settings file management to puppetlabs-concat.