### PR TITLE
Fix limits_template on Debian

### DIFF
--- a/data/Debian.yaml
+++ b/data/Debian.yaml
@@ -1,3 +1,3 @@
 ---
 
-limits::limits_template: 'limits.conf.ubuntu'
+limits::limits_template: 'limits.conf.debian'


### PR DESCRIPTION
Module hiera contains reference to a non-existent template (introduced in #44)